### PR TITLE
Reinstate serialization+mmap support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,9 +106,13 @@ set(firepony_common_sources
     command_line.h
     io_thread.cu
     io_thread.h
+    mmap.cu
+    mmap.h
     runtime_options.h
     segmented_database.h
     sequence_database.h
+    serialization.h
+    serialization_inl.h
     string_database.cu
     string_database.h
     table_formatter.cu
@@ -139,5 +143,9 @@ target_link_libraries(firepony firepony-device firepony-common ${tbb_LIB} ${gamg
 cuda_add_executable(firepony-vcf-convert firepony-vcf-convert.cu)
 target_link_libraries(firepony-vcf-convert ${gamgee_LIB} ${zlib_LIB} ${SYSTEM_LINK_LIBRARIES})
 add_dependencies(firepony-vcf-convert gamgee zlib)
+
+cuda_add_executable(firepony-loader firepony-loader.cu)
+target_link_libraries(firepony-loader firepony-common ${gamgee_LIB} ${zlib_LIB} ${SYSTEM_LINK_LIBRARIES})
+add_dependencies(firepony-loader firepony-common gamgee zlib)
 
 cuda_build_clean_target()

--- a/command_line.cu
+++ b/command_line.cu
@@ -49,6 +49,7 @@ static void usage(void)
     fprintf(stderr, "  -d, --debug                           Enable debugging (*extremely* verbose)\n");
     fprintf(stderr, "  --disable-rounding                    Disable rounding on the output tables\n");
     fprintf(stderr, "  -b, --batch-size <n>                  Process input in batches of <n> reads\n");
+    fprintf(stderr, "  --mmap                                Load reference/dbsnp from system shared memory if present\n");
 #if ENABLE_CUDA_BACKEND
     fprintf(stderr, "  --gpu-only                            Use only the CUDA GPU-accelerated backend\n");
 #endif
@@ -111,6 +112,7 @@ void parse_command_line(int argc, char **argv)
             { "debug", no_argument, NULL, 'd' },
             { "disable-rounding", no_argument, NULL, 'n' },
             { "batch-size", required_argument, NULL, 'b' },
+            { "mmap", no_argument, NULL, 'm' },
 #if ENABLE_CUDA_BACKEND
             { "gpu-only", no_argument, NULL, 'g' },
 #endif
@@ -167,6 +169,11 @@ void parse_command_line(int argc, char **argv)
                 usage();
             }
 
+            break;
+
+        case 'm':
+            // --mmap
+            command_line_options.try_mmap = true;
             break;
 
 #if ENABLE_CUDA_BACKEND

--- a/firepony-loader.cu
+++ b/firepony-loader.cu
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2012-14, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
+#include <unistd.h>
+#include <getopt.h>
+
+#include <string>
+
+#include "loader/reference.h"
+#include "loader/variants.h"
+#include "sequence_database.h"
+#include "variant_database.h"
+#include "mmap.h"
+#include "serialization.h"
+
+using namespace firepony;
+
+template <typename T>
+void create_shmem_segment(const char *fname, const T& data)
+{
+    shared_memory_file shmem;
+    size_t size;
+    bool ret;
+
+    size = serialization::serialized_size(data);
+
+    fprintf(stderr, "%s: allocating %lu MB of shared memory...\n", fname, size / (1024 * 1024));
+    ret = shared_memory_file::create(&shmem, fname, size);
+    if(ret == false)
+    {
+        fprintf(stderr, "failed to create shared memory segment for %s\n", fname);
+        exit(1);
+    }
+
+    serialization::serialize(shmem.data, data);
+    shmem.unmap();
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        fprintf(stderr, "usage: %s <reference.fa> <variants.vcf>\n", argv[0]);
+        exit(1);
+    }
+
+    const char *fasta = argv[1];
+    const char *vcf = argv[2];
+
+    // open the reference file
+    reference_file_handle *ref_h = reference_file_handle::open(fasta, 1, false);
+    if (ref_h == nullptr)
+    {
+        fprintf(stderr, "could not load %s\n", fasta);
+        exit(1);
+    }
+
+    // load the variant database
+    // this will populate the reference database as well
+    variant_database_host h_dbsnp;
+    bool ret;
+
+    fprintf(stderr, "loading variant database %s...", vcf);
+    fflush(stderr);
+
+    ret = load_vcf(&h_dbsnp, ref_h, vcf, false);
+    fprintf(stderr, "\n");
+    if (ret == false)
+    {
+        fprintf(stderr, "could not load %s\n", vcf);
+        exit(1);
+    }
+
+    create_shmem_segment(fasta, ref_h->sequence_data);
+    create_shmem_segment(vcf, h_dbsnp);
+
+    return 0;
+}

--- a/firepony.cu
+++ b/firepony.cu
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
     data_io.start();
 
     // load the reference genome
-    ref_h = reference_file_handle::open(command_line_options.reference, compute_devices.size());
+    ref_h = reference_file_handle::open(command_line_options.reference, compute_devices.size(), command_line_options.try_mmap);
 
     if (ref_h == nullptr)
     {
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 
     fprintf(stderr, "loading variant database %s...", command_line_options.snp_database);
     fflush(stderr);
-    ret = load_vcf(&h_dbsnp, ref_h, command_line_options.snp_database);
+    ret = load_vcf(&h_dbsnp, ref_h, command_line_options.snp_database, command_line_options.try_mmap);
     fprintf(stderr, "\n");
 
     if (ret == false)

--- a/loader/reference.cu
+++ b/loader/reference.cu
@@ -43,6 +43,9 @@
 #include "../device/util.h"
 #include "../device/from_nvbio/dna.h"
 
+#include "../mmap.h"
+#include "../serialization.h"
+
 namespace firepony {
 
 #include <thrust/iterator/transform_iterator.h>
@@ -71,12 +74,29 @@ static void load_record(sequence_database_host *output, const gamgee::Fastq& rec
 }
 
 // loader for sequence data
-static void load_reference(sequence_database_host *output, const char *filename)
+static void load_reference(sequence_database_host *output, const char *filename, bool try_mmap)
 {
-    for (gamgee::Fastq& record : gamgee::FastqReader(std::string(filename)))
+    bool loaded = false;
+
+    if (try_mmap)
     {
-        load_record(output, record);
-   }
+        shared_memory_file shmem;
+
+        loaded = shared_memory_file::open(&shmem, filename);
+        if (loaded == true)
+        {
+            serialization::unserialize(output, shmem.data);
+            shmem.unmap();
+        }
+    }
+
+    if (!loaded)
+    {
+        for (gamgee::Fastq& record : gamgee::FastqReader(std::string(filename)))
+        {
+            load_record(output, record);
+        }
+    }
 }
 
 static void load_one_sequence(sequence_database_host *output, const std::string filename, size_t file_offset)
@@ -147,7 +167,7 @@ bool reference_file_handle::load_index()
     return true;
 }
 
-reference_file_handle *reference_file_handle::open(const std::string filename, uint32 consumers)
+reference_file_handle *reference_file_handle::open(const std::string filename, uint32 consumers, bool try_mmap)
 {
     reference_file_handle *handle = new reference_file_handle(filename, consumers);
 
@@ -155,7 +175,7 @@ reference_file_handle *reference_file_handle::open(const std::string filename, u
     {
         // no index present, load entire reference
         fprintf(stderr, "WARNING: index not available for reference file %s, loading entire reference\n", filename.c_str());
-        load_reference(&handle->sequence_data, filename.c_str());
+        load_reference(&handle->sequence_data, filename.c_str(), try_mmap);
     } else {
         fprintf(stderr, "loaded index for %s\n", filename.c_str());
 
@@ -165,6 +185,19 @@ reference_file_handle *reference_file_handle::open(const std::string filename, u
             fprintf(stderr, "error opening %s\n", filename.c_str());
             delete handle;
             return nullptr;
+        }
+
+        if (try_mmap)
+        {
+            shared_memory_file shmem;
+            bool ret;
+
+            ret = shared_memory_file::open(&shmem, filename.c_str());
+            if (ret == true)
+            {
+                serialization::unserialize(&handle->sequence_data, shmem.data);
+                shmem.unmap();
+            }
         }
     }
 

--- a/loader/reference.h
+++ b/loader/reference.h
@@ -54,7 +54,7 @@ struct reference_file_handle
 
     bool make_sequence_available(const std::string& sequence_name);
 
-    static reference_file_handle *open(const std::string filename, uint32 consumers);
+    static reference_file_handle *open(const std::string filename, uint32 consumers, bool try_mmap);
 
     void consumer_lock(const uint32 consumer_id);
     void consumer_unlock(const uint32 consumer_id);

--- a/loader/variants.h
+++ b/loader/variants.h
@@ -32,6 +32,6 @@
 
 namespace firepony {
 
-bool load_vcf(variant_database_host *output, reference_file_handle *reference_handle, const char *filename);
+bool load_vcf(variant_database_host *output, reference_file_handle *reference_handle, const char *filename, bool try_mmap);
 
 } // namespace firepony

--- a/mmap.cu
+++ b/mmap.cu
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2012-14, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <string>
+
+#include "mmap.h"
+
+namespace firepony {
+
+shared_memory_file::shared_memory_file()
+    : fd(-1),
+      size(0),
+      data(nullptr)
+{
+}
+
+void shared_memory_file::unmap(void)
+{
+    if (data)
+    {
+        munmap(data, size);
+        data = nullptr;
+    }
+
+    size = 0;
+
+    if (fd != -1)
+    {
+        close(fd);
+        fd = -1;
+    }
+}
+
+// given a file name, either relative or absolute, compute the shmem handle name
+// returns "" in case of error
+static std::string compute_shmem_path(const char *fname)
+{
+    std::string ret;
+    char *abs_path = NULL;
+
+    // convert fname into a full path name
+    abs_path = realpath(fname, NULL);
+    if (abs_path == NULL)
+    {
+        return std::string("");
+    }
+
+    // replace all slashes with underscores
+    for(unsigned int i = 0; i < strlen(abs_path); i++)
+    {
+        if (abs_path[i] == '/')
+        {
+            abs_path[i] = '_';
+        }
+    }
+
+    ret = std::string("/firepony_") + std::string(abs_path);
+    free(abs_path);
+
+    return ret;
+}
+
+bool shared_memory_file::open(shared_memory_file *out, const char *fname)
+{
+    std::string shmem_path;
+    struct stat st;
+    int ret;
+
+    // compute the shmem handle path
+    shmem_path = compute_shmem_path(fname);
+    if (shmem_path.size() == 0)
+    {
+        return false;
+    }
+
+    // open it
+    out->fd = shm_open(shmem_path.c_str(), O_RDONLY, 0);
+    if (out->fd == -1)
+    {
+        return false;
+    }
+
+    // figure out how big the shared memory block is
+    ret = fstat(out->fd, &st);
+    if (ret == -1)
+    {
+        close(out->fd);
+        return false;
+    }
+
+    out->size = st.st_size;
+
+    // map it into our address space
+    int map_flags = MAP_SHARED;
+
+    out->data = mmap(NULL, st.st_size, PROT_READ, map_flags, out->fd, 0);
+    if (out->data == MAP_FAILED)
+    {
+        close(out->fd);
+        return false;
+    }
+
+    return true;
+}
+
+bool shared_memory_file::create(shared_memory_file *out, const char *fname, size_t size)
+{
+    std::string shmem_path;
+    int ret;
+
+    // compute the shmem handle path
+    shmem_path = compute_shmem_path(fname);
+    if (shmem_path.size() == 0)
+    {
+        return false;
+    }
+
+    // open it, truncating if the file exists
+    out->fd = shm_open(shmem_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (out->fd == -1)
+    {
+        return false;
+    }
+
+    ret = ftruncate(out->fd, size);
+    if (ret == -1)
+    {
+        close(out->fd);
+        return false;
+    }
+
+    out->size = size;
+
+    // map it into our address space
+    int map_flags = MAP_SHARED;
+
+    out->data = mmap(NULL, out->size, PROT_READ | PROT_WRITE, map_flags, out->fd, 0);
+    if (out->data == MAP_FAILED)
+    {
+        perror("mmap");
+        close(out->fd);
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace firepony
+

--- a/mmap.h
+++ b/mmap.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2012-14, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
+#pragma once
+
+#include <sys/types.h>
+#include <vector>
+
+#include "device_types.h"
+
+namespace firepony {
+
+struct shared_memory_file
+{
+    int fd;
+    size_t size;
+    void *data;
+
+    shared_memory_file();
+    void unmap(void);
+
+    // open a shared memory segment and create a read-only mapping for it
+    static bool open(shared_memory_file *out, const char *fname);
+    // create a new shared memory segment of a given size with a read-write mapping
+    static bool create(shared_memory_file *out, const char *fname, size_t size);
+};
+
+} // namespace firepony
+

--- a/runtime_options.h
+++ b/runtime_options.h
@@ -54,6 +54,9 @@ struct runtime_options
     bool enable_cuda;
     bool enable_tbb;
 
+    // enable the shared memory reference/dbsnp loader
+    bool try_mmap;
+
     void disable_all_backends(void)
     {
         enable_cuda = false;
@@ -75,6 +78,8 @@ struct runtime_options
 
         enable_cuda = true;
         enable_tbb = true;
+
+        try_mmap = false;
     }
 };
 

--- a/serialization.h
+++ b/serialization.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2012-14, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
+#pragma once
+
+#include "types.h"
+
+namespace firepony {
+
+struct serialization
+{
+    template <typename T>
+    static inline size_t serialized_size(const T&);
+    template <typename T>
+    static inline size_t serialized_size(const vector<host, T>&);
+    template <typename T>
+    static inline size_t serialized_size(const std::vector<T>&);
+    template <uint32 bits>
+    static inline size_t serialized_size(const packed_vector<host, bits>&);
+
+    template <typename T>
+    static inline void *serialize(void *out, const T& in);
+    template <typename T>
+    static inline void *serialize(void *out, const vector<host, T>&);
+    template <typename T>
+    static inline void *serialize(void *out, const std::vector<T>&);
+    template <uint32 bits>
+    static inline void *serialize(void *out, const packed_vector<host, bits>&);
+
+    template <typename T>
+    static inline void *unserialize(T *out, void *in);
+    template <typename T>
+    static inline void *unserialize(vector<host, T> *out, void *in);
+    template <typename T>
+    static inline void *unserialize(std::vector<T> *out, void *in);
+    template <uint32 bits>
+    static inline void *unserialize(packed_vector<host, bits> *out, void *in);
+};
+
+} // namespace firepony
+
+#include "serialization_inl.h"
+

--- a/serialization_inl.h
+++ b/serialization_inl.h
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2012-14, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
+#pragma once
+
+#include "variant_database.h"
+
+namespace firepony {
+
+// serialization primitives
+
+//// arbitrary integral type
+template <typename T>
+inline size_t serialization::serialized_size(const T&)
+{
+    return sizeof(T);
+}
+
+template <typename T>
+inline void *serialization::serialize(void *out, const T& in)
+{
+    T data = in;
+    memcpy(out, &data, sizeof(T));
+    return static_cast<char *>(out) + sizeof(T);
+}
+
+template <typename T>
+inline void *serialization::unserialize(T *out, void *in)
+{
+    memcpy(out, in, sizeof(T));
+    return static_cast<char *>(in) + sizeof(T);
+}
+
+
+//// std::string
+template <>
+inline size_t serialization::serialized_size<std::string>(const std::string& str)
+{
+    return str.size() + 1;
+}
+
+template <>
+inline void *serialization::serialize<std::string>(void *out, const std::string& in)
+{
+    size_t len = strlen(in.c_str()) + 1;
+    memcpy(out, in.c_str(), len);
+    out = static_cast<char *>(out) + len;
+
+    return out;
+}
+
+template <>
+inline void *serialization::unserialize<std::string>(std::string *out, void *in)
+{
+    *out = std::string((char *)in);
+    in = static_cast<char *>(in) + out->size() + 1;
+
+    return in;
+}
+
+
+//// std::vector
+template <typename T>
+inline size_t serialization::serialized_size(const std::vector<T>& vec)
+{
+    return sizeof(size_t) + sizeof(T) * vec.size();
+}
+
+template <typename T>
+inline void *serialization::serialize(void *out, const std::vector<T>& in)
+{
+    size_t size = in.size();
+    out = serialize(out, size);
+
+    for(size_t i = 0; i < size; i++)
+    {
+        out = serialize(out, in[i]);
+    }
+
+    return out;
+}
+
+template <typename T>
+inline void *serialization::unserialize(std::vector<T> *out, void *in)
+{
+    size_t size;
+    in = unserialize(&size, in);
+
+    out->resize(size);
+    for(size_t i = 0; i < size; i++)
+    {
+        in = unserialize(&((*out)[i]), in);
+    }
+
+    return in;
+}
+
+
+//// firepony host vector
+template <typename T>
+inline size_t serialization::serialized_size(const vector<host, T>& vec)
+{
+    return sizeof(size_t) + sizeof(T) * vec.size();
+}
+
+template <typename T>
+inline void *serialization::serialize(void *out, const vector<host, T>& in)
+{
+    size_t size = in.size();
+    out = serialize(out, size);
+
+    for(size_t i = 0; i < size; i++)
+    {
+        out = serialize(out, in[i]);
+    }
+
+    return out;
+}
+
+template <typename T>
+inline void *serialization::unserialize(vector<host, T> *out, void *in)
+{
+    size_t size;
+    in = unserialize(&size, in);
+
+    out->resize(size);
+
+    for(size_t i = 0; i < size; i++)
+    {
+        in = unserialize(&((*out)[i]), in);
+    }
+
+    return in;
+}
+
+
+//// firepony packed vector
+template <uint32 bits>
+inline size_t serialization::serialized_size(const packed_vector<host, bits>& vec)
+{
+    return serialized_size(vec.m_size) + serialized_size(vec.m_storage);
+}
+
+template <uint32 bits>
+inline void *serialization::serialize(void *out, const packed_vector<host, bits>& in)
+{
+    out = serialize(out, in.m_size);
+    out = serialize(out, in.m_storage);
+
+    return out;
+}
+
+template <uint32 bits>
+inline void *serialization::unserialize(packed_vector<host, bits> *out, void *in)
+{
+    in = unserialize(&out->m_size, in);
+    in = unserialize(&out->m_storage, in);
+
+    return in;
+}
+
+
+//// string database
+template <>
+inline size_t serialization::serialized_size(const string_database& db)
+{
+    return serialized_size(db.string_identifiers);
+}
+
+template <>
+inline void *serialization::serialize(void *out, const string_database& db)
+{
+    return serialize(out, db.string_identifiers);
+}
+
+template <>
+inline void *serialization::unserialize(string_database *out, void *in)
+{
+    in = unserialize(&out->string_identifiers, in);
+
+    out->string_hash_to_id.clear();
+
+    for(uint32 i = 0; i < out->string_identifiers.size(); i++)
+    {
+        const std::string& str = out->string_identifiers[i];
+        const uint32 h = string_database::hash(str);
+
+        out->string_hash_to_id[h] = i;
+    }
+
+    return in;
+}
+
+
+//// sequence storage
+template <>
+inline size_t serialization::serialized_size(const sequence_storage<host>& data)
+{
+    return serialized_size(data.bases);
+}
+
+template <>
+inline void *serialization::serialize(void *out, const sequence_storage<host>& data)
+{
+    return serialize(out, data.bases);
+}
+
+template <>
+inline void *serialization::unserialize(sequence_storage<host> *data, void *in)
+{
+    in = unserialize(&data->bases, in);
+    return in;
+}
+
+
+//// host sequence database
+template <>
+inline size_t serialization::serialized_size(const sequence_database_host& db)
+{
+    size_t ret = 0;
+
+    ret += serialized_size(db.sequence_names);
+
+    size_t size = db.storage.size();
+    ret += serialized_size(size);
+    for(size_t i = 0; i < size; i++)
+    {
+        ret += serialized_size(*(db.storage[i]));
+    }
+
+    return ret;
+}
+
+template <>
+inline void *serialization::serialize(void *out, const sequence_database_host& db)
+{
+    out = serialize(out, db.sequence_names);
+
+    out = serialize(out, db.storage.size());
+    for(size_t i = 0; i < db.storage.size(); i++)
+    {
+        out = serialize(out, *(db.storage[i]));
+    }
+
+    return out;
+}
+
+template <>
+inline void *serialization::unserialize(sequence_database_host *db, void *in)
+{
+    in = unserialize(&db->sequence_names, in);
+
+    size_t size;
+    in = unserialize(&size, in);
+
+    for(size_t i = 0; i < size; i++)
+    {
+        auto *seq = db->new_entry(i);
+        in = unserialize(seq, in);
+    }
+
+    return in;
+}
+
+
+//// variant storage
+template <>
+inline size_t serialization::serialized_size(const variant_storage<host>& v)
+{
+    size_t ret = 0;
+
+    ret += serialized_size(v.feature_start);
+    ret += serialized_size(v.feature_stop);
+    ret += serialized_size(v.max_end_point_left);
+
+    return ret;
+}
+
+template <>
+inline void *serialization::serialize(void *out, const variant_storage<host>& v)
+{
+    out = serialize(out, v.feature_start);
+    out = serialize(out, v.feature_stop);
+    out = serialize(out, v.max_end_point_left);
+
+    return out;
+}
+
+template <>
+inline void *serialization::unserialize(variant_storage<host> *v, void *in)
+{
+    in = unserialize(&v->feature_start, in);
+    in = unserialize(&v->feature_stop, in);
+    in = unserialize(&v->max_end_point_left, in);
+
+    return in;
+}
+
+
+//// variant database
+template <>
+inline size_t serialization::serialized_size(const variant_database_host& db)
+{
+    size_t ret = 0;
+
+    ret += serialized_size(db.storage.size());
+    for(size_t i = 0; i < db.storage.size(); i++)
+    {
+        ret += serialized_size(*(db.storage[i]));
+    }
+
+    return ret;
+}
+
+template <>
+inline void *serialization::serialize(void *out, const variant_database_host& db)
+{
+    out = serialize(out, db.storage.size());
+    for(size_t i = 0; i < db.storage.size(); i++)
+    {
+        out = serialize(out, *(db.storage[i]));
+    }
+
+    return out;
+}
+
+template <>
+inline void *serialization::unserialize(variant_database_host *db, void *in)
+{
+    size_t size;
+    in = unserialize(&size, in);
+
+    for(size_t i = 0; i < size; i++)
+    {
+        auto *seq = db->new_entry(i);
+        in = unserialize(seq, in);
+    }
+
+    return in;
+}
+
+} // namespace firepony

--- a/string_database.h
+++ b/string_database.h
@@ -38,6 +38,8 @@ namespace firepony {
 // utility struct to keep track of string identifiers using integers
 struct string_database
 {
+    friend struct serialization;
+
     // returns the id of string if it exists in the database, otherwise returns -1
     uint32 lookup(const std::string& string) const;
     // returns the string corresponding to the given integer id


### PR DESCRIPTION
Adds back the reference/dbsnp serialization support and supporting code
to read/write to system shared memory locations.

The approach is a little simpler than before as we no longer care about
minimizing memory usage (this is meant solely as a debug tool to speed
up the process of bisecting large input files).